### PR TITLE
Fix share text (`Wordle` -> `Not Wordle`)

### DIFF
--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -3,12 +3,8 @@ import { solutionIndex } from './words'
 
 export const shareStatus = (guesses: string[]) => {
   navigator.clipboard.writeText(
-    'Wordle ' +
-      solutionIndex +
-      ' ' +
-      guesses.length +
-      '/6\n\n' +
-      generateEmojiGrid(guesses)
+    `Not Wordle ${solutionIndex} ${guesses.length}/6\n\n` +
+    generateEmojiGrid(guesses)
   )
 }
 


### PR DESCRIPTION
I changed the share text to distinguish this clone from the original.