### PR TITLE
Feature: share to mobile apps and fallback to clipboard if browser is not supported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,9 @@
         "postcss": "^8.4.5",
         "prettier": "^2.5.1",
         "tailwindcss": "^3.0.12"
+      },
+      "engines": {
+        "node": "^14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "engines": {
+    "node": "^14.0.0"
+  },
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { InformationCircleIcon } from '@heroicons/react/outline'
 import { ChartBarIcon } from '@heroicons/react/outline'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { Alert } from './components/alerts/Alert'
 import { Grid } from './components/grid/Grid'
 import { Keyboard } from './components/keyboard/Keyboard'
@@ -18,14 +18,14 @@ import {
 function App() {
   const [currentGuess, setCurrentGuess] = useState('')
   const [isGameWon, setIsGameWon] = useState(false)
-  const [isWinModalOpen, setIsWinModalOpen] = useState(false)
+  const [isWinningModalOpen, setIsWinningModalOpen] = useState(false)
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(false)
   const [isAboutModalOpen, setIsAboutModalOpen] = useState(false)
   const [isNotEnoughLetters, setIsNotEnoughLetters] = useState(false)
   const [isStatsModalOpen, setIsStatsModalOpen] = useState(false)
   const [isWordNotFoundAlertOpen, setIsWordNotFoundAlertOpen] = useState(false)
   const [isGameLost, setIsGameLost] = useState(false)
-  const [shareComplete, setShareComplete] = useState(false)
+  const [showCopyToClipboardComplete, setShowCopyToClipboardComplete] = useState(false)
   const [guesses, setGuesses] = useState<string[]>(() => {
     const loaded = loadGameStateFromLocalStorage()
     if (loaded?.solution !== solution) {
@@ -49,7 +49,7 @@ function App() {
 
   useEffect(() => {
     if (isGameWon) {
-      setIsWinModalOpen(true)
+      setIsWinningModalOpen(true)
     }
   }, [isGameWon])
 
@@ -96,6 +96,19 @@ function App() {
     }
   }
 
+  const winModalOnShare = useCallback((isShareToClipboard: boolean) => {
+    if (isShareToClipboard) {
+      setShowCopyToClipboardComplete(true)
+      return setTimeout(() => {
+        setShowCopyToClipboardComplete(false)
+      }, 2000)
+    }
+  }, [])
+
+  const winModalOffShare = useCallback(() => {
+    setIsWinningModalOpen(false)
+  }, [])
+
   return (
     <div className="py-8 max-w-7xl mx-auto sm:px-6 lg:px-8">
       <div className="flex w-80 mx-auto items-center mb-8">
@@ -117,16 +130,11 @@ function App() {
         guesses={guesses}
       />
       <WinModal
-        isOpen={isWinModalOpen}
-        handleClose={() => setIsWinModalOpen(false)}
+        isOpen={isWinningModalOpen}
+        handleClose={() => setIsWinningModalOpen(false)}
         guesses={guesses}
-        handleShare={() => {
-          setIsWinModalOpen(false)
-          setShareComplete(true)
-          return setTimeout(() => {
-            setShareComplete(false)
-          }, 2000)
-        }}
+        onShare={winModalOnShare}
+        offShare={winModalOffShare}
       />
       <InfoModal
         isOpen={isInfoModalOpen}
@@ -158,7 +166,7 @@ function App() {
       />
       <Alert
         message="Game copied to clipboard"
-        isOpen={shareComplete}
+        isOpen={showCopyToClipboardComplete}
         variant="success"
       />
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,26 +17,18 @@ import {
 
 function App() {
   const [currentGuess, setCurrentGuess] = useState('')
-  const [isGameWon, setIsGameWon] = useState(false)
   const [isWinningModalOpen, setIsWinningModalOpen] = useState(false)
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(false)
   const [isAboutModalOpen, setIsAboutModalOpen] = useState(false)
   const [isNotEnoughLetters, setIsNotEnoughLetters] = useState(false)
   const [isStatsModalOpen, setIsStatsModalOpen] = useState(false)
   const [isWordNotFoundAlertOpen, setIsWordNotFoundAlertOpen] = useState(false)
-  const [isGameLost, setIsGameLost] = useState(false)
+  const [isLosingAlertOpen, setIsLosingAlertOpen] = useState(false)
   const [showCopyToClipboardComplete, setShowCopyToClipboardComplete] = useState(false)
   const [guesses, setGuesses] = useState<string[]>(() => {
     const loaded = loadGameStateFromLocalStorage()
     if (loaded?.solution !== solution) {
       return []
-    }
-    const gameWasWon = loaded.guesses.includes(solution)
-    if (gameWasWon) {
-      setIsGameWon(true)
-    }
-    if (loaded.guesses.length === 6 && !gameWasWon) {
-      setIsGameLost(true)
     }
     return loaded.guesses
   })
@@ -47,24 +39,36 @@ function App() {
     saveGameStateToLocalStorage({ guesses, solution })
   }, [guesses])
 
+  const isWinningGame = guesses.length > 0 && isWinningWord(guesses[guesses.length - 1])
+  const isLosingGame = guesses.length === 6 && !isWinningGame
+  const isInputDisabled = isWinningGame || isLosingGame
+
   useEffect(() => {
-    if (isGameWon) {
+    if (isWinningGame) {
+      setStats(s => addStatsForCompletedGame(s, guesses.length))
       setIsWinningModalOpen(true)
     }
-  }, [isGameWon])
-
-  const onChar = (value: string) => {
-    if (currentGuess.length < 5 && guesses.length < 6 && !isGameWon) {
-      setCurrentGuess(`${currentGuess}${value}`)
+    if (isLosingGame) {
+      setStats(s => addStatsForCompletedGame(s, -1))
+      setIsLosingAlertOpen(true)
+      setTimeout(() => {
+        setIsLosingAlertOpen(false)
+      }, 2000)
     }
-  }
+  }, [isWinningGame, isLosingGame, guesses.length])
 
-  const onDelete = () => {
-    setCurrentGuess(currentGuess.slice(0, -1))
-  }
+  const onChar = useCallback((value: string) => {
+    if (!isInputDisabled && currentGuess.length < 5) {
+      setCurrentGuess(currGuess => `${currGuess}${value}`)
+    }
+  }, [currentGuess.length, isInputDisabled])
 
-  const onEnter = () => {
-    if (!(currentGuess.length === 5) && !isGameLost) {
+  const onDelete = useCallback(() => {
+    setCurrentGuess(currGuess => currGuess.slice(0, -1))
+  }, [])
+
+  const onEnter = useCallback(() => {
+    if (!(currentGuess.length === 5)) {
       setIsNotEnoughLetters(true)
       return setTimeout(() => {
         setIsNotEnoughLetters(false)
@@ -78,23 +82,12 @@ function App() {
       }, 2000)
     }
 
-    const winningWord = isWinningWord(currentGuess)
-
-    if (currentGuess.length === 5 && guesses.length < 6 && !isGameWon) {
-      setGuesses([...guesses, currentGuess])
+    if (!isInputDisabled && currentGuess.length === 5) {
+      setGuesses(g => [...g, currentGuess])
+      // reset current guess after append it to guesses
       setCurrentGuess('')
-
-      if (winningWord) {
-        setStats(addStatsForCompletedGame(stats, guesses.length))
-        return setIsGameWon(true)
-      }
-
-      if (guesses.length === 5) {
-        setStats(addStatsForCompletedGame(stats, guesses.length + 1))
-        setIsGameLost(true)
-      }
     }
-  }
+  }, [currentGuess, isInputDisabled])
 
   const winModalOnShare = useCallback((isShareToClipboard: boolean) => {
     if (isShareToClipboard) {
@@ -162,7 +155,7 @@ function App() {
       <Alert message="Word not found" isOpen={isWordNotFoundAlertOpen} />
       <Alert
         message={`You lost, the word was ${solution}`}
-        isOpen={isGameLost}
+        isOpen={isLosingAlertOpen}
       />
       <Alert
         message="Game copied to clipboard"

--- a/src/components/modals/WinModal.tsx
+++ b/src/components/modals/WinModal.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { Dialog } from '@headlessui/react'
 import { CheckIcon } from '@heroicons/react/outline'
 import { MiniGrid } from '../mini-grid/MiniGrid'
@@ -8,15 +9,20 @@ type Props = {
   isOpen: boolean
   handleClose: () => void
   guesses: string[]
-  handleShare: () => void
+  onShare: (isShareToClipboard: boolean) => void
+  offShare: () => void
 }
 
 export const WinModal = ({
   isOpen,
   handleClose,
   guesses,
-  handleShare,
+  onShare,
+  offShare,
 }: Props) => {
+  const onBtnClick = useCallback(() => {
+    shareStatus(guesses).then(onShare).finally(offShare)
+  }, [guesses, onShare, offShare])
   return (
     <BaseModal title="You won!" isOpen={isOpen} handleClose={handleClose}>
       <div>
@@ -40,10 +46,7 @@ export const WinModal = ({
         <button
           type="button"
           className="inline-flex justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:text-sm"
-          onClick={() => {
-            shareStatus(guesses)
-            handleShare()
-          }}
+          onClick={onBtnClick}
         >
           Share
         </button>

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,34 +1,28 @@
 import { getGuessStatuses } from './statuses'
 import { solutionIndex } from './words'
 
-export const shareStatus = (guesses: string[]) => {
-  navigator.clipboard.writeText(
-    'Wordle ' +
-      solutionIndex +
-      ' ' +
-      guesses.length +
-      '/6\n\n' +
-      generateEmojiGrid(guesses)
-  )
+export const shareStatus = async (guesses: string[]): Promise<boolean> => {
+  const text = `Not Wordle ${solutionIndex} ${guesses.length}/6\n\n${generateEmojiGrid(guesses)}`;
+  if (navigator.share) {
+    return navigator.share({ text: text }).then(() => false)
+  }
+  return navigator.clipboard.writeText(text).then(() => true)
 }
 
 export const generateEmojiGrid = (guesses: string[]) => {
   return guesses
     .map((guess) => {
       const status = getGuessStatuses(guess)
-      return guess
-        .split('')
-        .map((letter, i) => {
-          switch (status[i]) {
-            case 'correct':
-              return '🟩'
-            case 'present':
-              return '🟨'
-            default:
-              return '⬜'
-          }
-        })
-        .join('')
+      return status.map(condition => {
+        switch (condition) {
+          case 'correct':
+            return '🟩'
+          case 'present':
+            return '🟨'
+          default:
+            return '⬜'
+        }
+      }).join('')
     })
     .join('\n')
 }

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -4,8 +4,12 @@ import {
   saveStatsToLocalStorage,
 } from './localStorage'
 
-// In stats array elements 0-5 are successes in 1-6 trys
-
+/**
+ *
+ * @param gameStats
+ * @param count winning game sends the guesses times from 1 - 6, losing game sends -1
+ * @returns
+ */
 export const addStatsForCompletedGame = (
   gameStats: GameStats,
   count: number
@@ -15,12 +19,13 @@ export const addStatsForCompletedGame = (
 
   stats.totalGames += 1
 
-  if (count > 5) {
+  if (count < 0) {
     // A fail situation
     stats.currentStreak = 0
     stats.gamesFailed += 1
   } else {
-    stats.winDistribution[count] += 1
+    // reindex from 1 to 6 to 0 to 5
+    stats.winDistribution[count - 1] += 1
     stats.currentStreak += 1
 
     if (stats.bestStreak < stats.currentStreak) {


### PR DESCRIPTION
# Proposal

## Major

- This pull request includes a feature "share to mobile apps" it still falls back to writing in clipboard if the browser is not supported.
- Refactor the App.tsx states
  - remove `isGameWon` state instead straightly obverve the `guesses` state to trigger `winModal` and `loseAlert` open
     guesses can reflect three status: winning, losing and playing.
        Game is a winning game when guesses.length is more than one and the last guess is the winning word 
        Game is a losing game when it is not winning game and guesses reach the maximum gussing times
		o.w. game is playing
  - decouple keyboard events from winning/losing verify logics. on-keyboards-enter simply append the `currentGuess` to `guesses` and keep the win/lose logic inside the `guesses` observation.

## Minor
- add node engine warning

## Screenshots
![image](https://user-images.githubusercontent.com/1487883/150726667-e414fe81-9b7d-468d-b9b6-9dde0ecbbbc7.png)
