### PR TITLE
histogram width divide by mode, not total

### DIFF
--- a/src/components/stats/Histogram.tsx
+++ b/src/components/stats/Histogram.tsx
@@ -6,7 +6,8 @@ type Props = {
 }
 
 export const Histogram = ({ gameStats }: Props) => {
-  const { totalGames, winDistribution } = gameStats
+  const winDistribution = gameStats.winDistribution
+  const maxValue = Math.max(...winDistribution)
 
   return (
     <div className="columns-1 justify-left m-2 text-sm">
@@ -14,7 +15,7 @@ export const Histogram = ({ gameStats }: Props) => {
         <Progress
           key={i}
           index={i}
-          size={95 * (value / Math.max(...winDistribution))}
+          size={90 * (value / maxValue)}
           label={String(value)}
         />
       ))}

--- a/src/components/stats/Histogram.tsx
+++ b/src/components/stats/Histogram.tsx
@@ -14,7 +14,7 @@ export const Histogram = ({ gameStats }: Props) => {
         <Progress
           key={i}
           index={i}
-          size={95 * (value / totalGames)}
+          size={95 * (value / Math.max(...winDistribution)}
           label={String(value)}
         />
       ))}

--- a/src/components/stats/Histogram.tsx
+++ b/src/components/stats/Histogram.tsx
@@ -14,7 +14,7 @@ export const Histogram = ({ gameStats }: Props) => {
         <Progress
           key={i}
           index={i}
-          size={95 * (value / Math.max(...winDistribution)}
+          size={95 * (value / Math.max(...winDistribution))}
           label={String(value)}
         />
       ))}


### PR DESCRIPTION
Divide by the value that occurs the most frequently, instead of the total games, so the histogram always uses the whole space available, rather than possibly getting smaller and smaller the more games are played.