### PR TITLE
Use local timezone instead of UTC-5

### DIFF
--- a/src/lib/words.ts
+++ b/src/lib/words.ts
@@ -14,7 +14,7 @@ export const isWinningWord = (word: string) => {
 
 export const getWordOfDay = () => {
   // January 1, 2022 Game Epoch
-  const epochMs = 1641013200000
+  const epochMs = new Date('January 1, 2022 00:00:00').valueOf()
   const now = Date.now()
   const msInDay = 86400000
   const index = Math.floor((now - epochMs) / msInDay)


### PR DESCRIPTION
Currently the epoch is based on Saturday, January 1, 2022 0:00:00 UTC-5. This changes it to use the local timezone. It's also cleaner if other forks want to use a different date for their epoch.